### PR TITLE
Add SINQ data link

### DIFF
--- a/start.py
+++ b/start.py
@@ -12,35 +12,41 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                 <a
                     class="feature"
                     href="{appbase}/plot.ipynb"
-                    target="_blank">
+                    target="_blank"
+                    title="Plot any 2D data (uploaded as CSV)"
+                >
                     <i
                         class="fa fa-bar-chart feature-logo"
                         style="font-size:40px;"
                         alt="Plot">
                     </i>
-                    <div class="feature-label">Plot GUI</div>
+                    <div class="feature-label">Plot 2D data</div>
                 </a>
                 <a
                     class="feature"
                     href="{appbase}/proposal_history.ipynb"
-                    target="_blank">
+                    target="_blank"
+                    title="Select and analyze data from the CAMEA instrument (using MJOLNIR)"
+                >
                     <i
                         class="fa fa-folder-open feature-logo"
                         style="font-size:40px;"
                         alt="Mjolnir analysis">
                     </i>
-                    <div class="feature-label">Analysis of CAMEA data (MJOLNIR)</div>
+                    <div class="feature-label">Analyze CAMEA data (MJOLNIR)</div>
                 </a>
                 <a
                     class="feature"
                     href="{appbase}/image-viewer-demo-ICON.ipynb"
-                    target="_blank">
+                    target="_blank"
+                    title="Select and analyze data from the ICON imaging instrument"
+                >
                     <i
                         class="fa fa-folder-open feature-logo"
                         style="font-size:40px;"
                         alt="Mjolnir analysis">
                     </i>
-                    <div class="feature-label">Analysis of ICON data</div>
+                    <div class="feature-label">Analyze ICON data</div>
                 </a>
             </div>
         </div>

--- a/start.py
+++ b/start.py
@@ -11,7 +11,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
             <div class="features">
                 <a
                     class="feature"
-                    href=f"{jupbase}/tree/SINQ_data"
+                    href="{jupbase}/tree/SINQ_data"
                     target="_blank"
                     title="Explore and download SINQ data from assigned instruments"
                 >

--- a/start.py
+++ b/start.py
@@ -11,7 +11,7 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
             <div class="features">
                 <a
                     class="feature"
-                    href="/tree/SINQ_data"
+                    href=f"{jupbase}/tree/SINQ_data"
                     target="_blank"
                     title="Explore and download SINQ data from assigned instruments"
                 >

--- a/start.py
+++ b/start.py
@@ -11,6 +11,19 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
             <div class="features">
                 <a
                     class="feature"
+                    href="/tree/SINQ_data"
+                    target="_blank"
+                    title="Explore and download SINQ data from assigned instruments"
+                >
+                    <i
+                        class="fa fa-folder-open feature-logo"
+                        style="font-size:40px;"
+                        alt="Plot">
+                    </i>
+                    <div class="feature-label">Explore SINQ data</div>
+                </a>
+                <a
+                    class="feature"
                     href="{appbase}/plot.ipynb"
                     target="_blank"
                     title="Plot any 2D data (uploaded as CSV)"

--- a/start.py
+++ b/start.py
@@ -4,8 +4,8 @@ import ipywidgets as ipw
 def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
     return ipw.HTML(f"""
         <div class="app-container">
-            <h1 
-            style="text-align:center; 
+            <h1
+            style="text-align:center;
             font-size:30px;">
             LNS apps and tools</h1>
             <div class="features">
@@ -13,9 +13,9 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     class="feature"
                     href="{appbase}/plot.ipynb"
                     target="_blank">
-                    <i 
-                        class="fa fa-bar-chart feature-logo" 
-                        style="font-size:40px;" 
+                    <i
+                        class="fa fa-bar-chart feature-logo"
+                        style="font-size:40px;"
                         alt="Plot">
                     </i>
                     <div class="feature-label">Plot GUI</div>
@@ -24,9 +24,9 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     class="feature"
                     href="{appbase}/proposal_history.ipynb"
                     target="_blank">
-                    <i 
-                        class="fa fa-folder-open feature-logo" 
-                        style="font-size:40px;" 
+                    <i
+                        class="fa fa-folder-open feature-logo"
+                        style="font-size:40px;"
                         alt="Mjolnir analysis">
                     </i>
                     <div class="feature-label">Analysis of CAMEA data (MJOLNIR)</div>
@@ -35,9 +35,9 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
                     class="feature"
                     href="{appbase}/image-viewer-demo-ICON.ipynb"
                     target="_blank">
-                    <i 
-                        class="fa fa-folder-open feature-logo" 
-                        style="font-size:40px;" 
+                    <i
+                        class="fa fa-folder-open feature-logo"
+                        style="font-size:40px;"
                         alt="Mjolnir analysis">
                     </i>
                     <div class="feature-label">Analysis of ICON data</div>
@@ -50,4 +50,3 @@ def get_start_widget(appbase, jupbase, notebase):  # noqa: ARG001
             <a href="https://www.psi.ch/en/sinq/icon" target="_blank">Go to ICON webpage</a>
         </div>
     """)
-    


### PR DESCRIPTION
This PR adds a new button in the home-app container linking to the **File Manager** page opened at `/home/jovyan/SINQ_data` (symlinked from `/mnt/SINQ_data`).